### PR TITLE
NO-TICKET: Unsubmitted Reminder Email

### DIFF
--- a/application/models/DbTable/Shipments.php
+++ b/application/models/DbTable/Shipments.php
@@ -236,8 +236,8 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract {
                 'TOTALSHIPMEN' => new Zend_Db_Expr("COUNT('s.shipment_id')")))
             ->joinLeft(array('sp' => 'shipment_participant_map'), 's.shipment_id=sp.shipment_id',
                     array(
-                        'ONTIME' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,3,1) WHEN 1 THEN 1 END)"),
-                        'NORESPONSE' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,2,1) WHEN 9 THEN 1 END)"),
+                        'ONTIME' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,4,1) WHEN 1 THEN 1 END)"),
+                        'NORESPONSE' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,3,1) WHEN 9 THEN 1 END)"),
                         'reported_count' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,4,1) WHEN '1' THEN 1 WHEN '2' THEN 1 END)")
                     ))
             ->joinLeft(array('pmm' => 'participant_manager_map'), 'pmm.participant_id=sp.participant_id', array())
@@ -274,8 +274,8 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract {
                 'SHIP_YEAR' => 'year(s.shipment_date)',
                 'TOTALSHIPMEN' => new Zend_Db_Expr("COUNT('s.shipment_id')")))
             ->joinLeft(array('sp' => 'shipment_participant_map'), 's.shipment_id=sp.shipment_id', array(
-                'ONTIME' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,3,1) WHEN 1 THEN 1 END)"),
-                'NORESPONSE' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,2,1) WHEN 9 THEN 1 END)"),
+                'ONTIME' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,4,1) WHEN 1 THEN 1 END)"),
+                'NORESPONSE' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,3,1) WHEN 9 THEN 1 END)"),
                 'reported_count' => new Zend_Db_Expr("COUNT(CASE substr(sp.evaluation_status,4,1) WHEN '1' THEN 1 WHEN '2' THEN 1 END)")))
             ->joinLeft(array('pmm' => 'participant_manager_map'), 'pmm.participant_id=sp.participant_id', array())
 			->joinLeft(array('sl' => 'scheme_list'), 'sl.scheme_id=s.scheme_type', array())

--- a/application/services/Shipments.php
+++ b/application/services/Shipments.php
@@ -1731,16 +1731,18 @@ class Application_Service_Shipments {
             ->join(array('sl' => 'scheme_list'), 'sl.scheme_id=s.scheme_type', array('SCHEME' => 'sl.scheme_name'))
             ->where("sp.shipment_id = ?", $params["shipmentId"]);
         if ($params["sendTo"] == "notSubmitted") {
-            $sQuery = $sQuery->where(new Zend_Db_Expr("substr(sp.evaluation_status, 2, 1) = '9'"));
+            $sQuery = $sQuery->where(new Zend_Db_Expr("substr(sp.evaluation_status, 3, 1) = '9'"));
         }
         if ($params["sendTo"] == "submitted") {
-            $sQuery = $sQuery->where(new Zend_Db_Expr("substr(sp.evaluation_status, 2, 1) = '1'"));
+            $sQuery = $sQuery->where(new Zend_Db_Expr("substr(sp.evaluation_status, 3, 1) = '1'"));
         }
         if ($params["sendTo"] == "saved") {
-            $sQuery = $sQuery->where("sp.shipment_receipt_date IS NOT NULL");
+            $sQuery = $sQuery->where("sp.shipment_receipt_date IS NOT NULL")
+                ->where(new Zend_Db_Expr("substr(sp.evaluation_status, 3, 1) = '9'"));
         }
         if ($params["sendTo"] == "neither") {
-            $sQuery = $sQuery->where("sp.shipment_receipt_date IS NULL");
+            $sQuery = $sQuery->where("sp.shipment_receipt_date IS NULL")
+                ->where(new Zend_Db_Expr("substr(sp.evaluation_status, 3, 1) = '9'"));
         }
         $sQuery = $sQuery->group("p.participant_id");
         $participantEmails = $db->fetchAll($sQuery);


### PR DESCRIPTION
When sending reminder emails to un-submitted participants, all participants received an email.

This fixes the filtering to excluded submitted participants.