### PR TITLE
Correct footer effective date as a static

### DIFF
--- a/application/modules/reports/views/scripts/distribution/generate-reports.ajax.phtml
+++ b/application/modules/reports/views/scripts/distribution/generate-reports.ajax.phtml
@@ -54,7 +54,7 @@ if (sizeof($this->result['shipment']) > 0) {
             $this->SetFont('Helvetica', '', 8);
             $this->Cell(30, 10, 'Form: ILB-500-F29A', 0, false, 'L', 0, '', 0, false, 'T', 'M');
             $this->Cell(120, 10, 'Issuing Authority: David Turgeon, PhD', 0, false, 'C', 0, '', 0, false, 'T', 'M');
-            $this->Cell(30, 10, sprintf('Effective Date: %s', date('F Y')), 0, false, 'R', 0, '', 0, false, 'T', 'M');
+            $this->Cell(30, 10, 'Effective Date: March 2022', 0, false, 'R', 0, '', 0, false, 'T', 'M');
         }
 
         public function writeHTMLTogether($html, $ln=true, $fill=false, $reseth=false, $cell=false, $align='') {

--- a/application/modules/reports/views/scripts/distribution/generate-summary-reports.ajax.phtml
+++ b/application/modules/reports/views/scripts/distribution/generate-summary-reports.ajax.phtml
@@ -46,7 +46,7 @@ if ($this->result['shipment'] != "") {
             $this->SetFont('Helvetica', '', 8);
             $this->Cell(30, 10, 'Form: ILB-500-F29A', 0, false, 'L', 0, '', 0, false, 'T', 'M');
             $this->Cell(120, 10, 'Issuing Authority: David Turgeon, PhD', 0, false, 'C', 0, '', 0, false, 'T', 'M');
-            $this->Cell(30, 10, sprintf('Effective Date: %s', date('F Y')), 0, false, 'R', 0, '', 0, false, 'T', 'M');
+            $this->Cell(30, 10, 'Effective Date: March 2022', 0, false, 'R', 0, '', 0, false, 'T', 'M');
             $this->SetY(-10);
             $this->Cell(0, 10, sprintf('Page %s / %s', $this->getAliasNumPage(), $this->getAliasNbPages()), 0, false, 'C', 0, '', 0, false, 'T', 'M');
         }


### PR DESCRIPTION
Make effective date static in Individual Performance and Summary Reports