### PR TITLE
Trello 69: Fix duplicate user creation bug

### DIFF
--- a/application/models/DbTable/ParticipantTemp.php
+++ b/application/models/DbTable/ParticipantTemp.php
@@ -72,12 +72,12 @@ class Application_Model_DbTable_ParticipantTemp extends Zend_Db_Table_Abstract {
             if ($participantTempRecords[$i]["insert"]) {
                 $participantTempRecords[$i]["import_action"] = "New";
             } else {
-                $participantTempRecords[$i]["update_lab_name"] = $participantTempRecords[$i]["lab_name"] != $participantTempRecords[$i]["old_lab_name"];
+                $participantTempRecords[$i]["update_lab_name"] = trim(strtolower($participantTempRecords[$i]["lab_name"])) != trim(strtolower($participantTempRecords[$i]["old_lab_name"]));
                 $participantTempRecords[$i]["update_country"] = $participantTempRecords[$i]["country"] != $participantTempRecords[$i]["old_country"];
                 $participantTempRecords[$i]["update_region"] = $participantTempRecords[$i]["region"] != $participantTempRecords[$i]["old_region"];
                 $participantTempRecords[$i]["update_username"] = $participantTempRecords[$i]["old_username"] &&
-                    $participantTempRecords[$i]["username"] != $participantTempRecords[$i]["old_username"];
-                $participantTempRecords[$i]["update_email"] = $participantTempRecords[$i]["email"] != $participantTempRecords[$i]["old_email"];
+                trim(strtolower($participantTempRecords[$i]["username"])) != trim(strtolower($participantTempRecords[$i]["old_username"]));
+                $participantTempRecords[$i]["update_email"] = trim(strtolower($participantTempRecords[$i]["email"])) != trim(strtolower($participantTempRecords[$i]["old_email"]));
                 $participantTempRecords[$i]["update_password"] = isset($participantTempRecords[$i]["password"]) &&
                     !!$participantTempRecords[$i]["password"] &&
                     $participantTempRecords[$i]["password"] != $participantTempRecords[$i]["old_password"] &&

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -690,7 +690,13 @@ class Application_Service_Participants {
             $accumulator[$country["iso_name"]] = $country;
             return $accumulator;
         }, $countriesMap);
-
+        for($i = 0; $i < count($tempParticipants); $i++) {
+            if (!isset($tempParticipants[$i]["Username"]) ||
+                $tempParticipants[$i]["Username"] == null ||
+                trim($tempParticipants[$i]["Username"]) == "") {
+                $tempParticipants[$i]["Username"] = $tempParticipants[$i]["PT ID"]."@ept.systemone.id";
+            }
+        }
         $emailAddressesInImport = array_column($tempParticipants, "Username");
         $dataManagerDb = new Application_Model_DbTable_DataManagers();
         $existingDataManagers = $dataManagerDb->getDataManagersByEmailAddresses($emailAddressesInImport);
@@ -930,7 +936,9 @@ class Application_Service_Participants {
                                 "phone1" => $dataManager["mobile"],
                                 "semail" => $dataManager["secondary_email"]
                             );
-                            if (!isset($dataManager["last_name"]) || $dataManager["last_name"] == null || $dataManager["last_name"] == "") {
+                            if (!isset($dataManager["last_name"]) ||
+                                $dataManager["last_name"] == null ||
+                                $dataManager["last_name"] == "") {
                                 $updatedUser["fname"] = $participantTempRecord["lab_name"];
                             }
                             if ($participantTempRecord["update_username"]) {
@@ -949,8 +957,12 @@ class Application_Service_Participants {
                         }
                         $dataManagerIds[] = $dataManager["dm_id"];
                     } else {
+                        $fname = $participantTempRecord["lab_name"];
+                        if (strlen($fname) > 45) {
+                            $fname = substr($fname, 0, 45);
+                        }
                         $newUser = array(
-                            'fname' => $participantTempRecord["lab_name"],
+                            'fname' => $fname,
                             'phone2' => $participantTempRecord['phone_number'],
                             'userId' => $participantTempRecord['username'],
                             'password' => $participantTempRecord['password'],

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -1138,6 +1138,18 @@ class Application_Service_Participants {
                     }
                     $participantDb->updateParticipant($updatedParticipant);
                 }
+            } else if ($participantTempRecord["insert_user_link"]) {
+                $participant = $participantDb->getParticipant($participantTempRecord["participant_id"]);
+                $dataManagerToLink = null;
+                if ($dataManagerToUpdate["dm_id"] != null) {
+                    $dataManagerToLink = $userService->getUserInfoBySystemId($dataManagerToUpdate["dm_id"]);
+                } else {
+                    $dataManagerToLink = $userService->getUserInfo($participantTempRecord["username"]);
+                }
+                $participantDb->addParticipantManager(array(
+                    "datamanagerId" => $dataManagerToLink["dm_id"],
+                    "participants" => array($participant["participant_id"])
+                ));
             }
         }
 


### PR DESCRIPTION
After testing Mariela's import, file on staging, these changes fix the unique constraint collision on the username when it is generated from <PT ID>@ept.systemone.id

This also implements linking of users to participants. An oversight that was missed during testing.