### PR TITLE
Trello 76 & 77: Generate Password & Usernames if Blank

### DIFF
--- a/application/controllers/AuthController.php
+++ b/application/controllers/AuthController.php
@@ -15,11 +15,11 @@ class AuthController extends Zend_Controller_Action
             $params = $this->getRequest()->getPost();
             $username = "";
             if (isset($params['username'])) {
-                $username = trim($params['username']);
+                $username = rtrim(ltrim($params['username']));
             }
             $password = "";
             if (isset($params['password'])) {
-                $password = trim($params['password']);
+                $password = rtrim(ltrim($params['password']));
             }
     		$db = Zend_Db_Table_Abstract::getDefaultAdapter();
     		$adapter = new Zend_Auth_Adapter_DbTable($db, "data_manager", "primary_email", "password");

--- a/application/models/DbTable/DataManagers.php
+++ b/application/models/DbTable/DataManagers.php
@@ -197,14 +197,24 @@ class Application_Model_DbTable_DataManagers extends Zend_Db_Table_Abstract {
     public function updateUser($params) {
 	    $authNameSpace = new Zend_Session_Namespace('administrators');
         $data = array(
-            'first_name' => $params['fname'],
-            'last_name' => $params['lname'],
-            'phone' => $params['phone2'],
-            'mobile' => $params['phone1'],
-            'secondary_email' => $params['semail'],
-	        'updated_by' => $authNameSpace->admin_id,
-            'updated_on' => new Zend_Db_Expr('now()')
+            "updated_by" => $authNameSpace->admin_id,
+            "updated_on" => new Zend_Db_Expr("now()")
         );
+        if (isset($params["fname"])) {
+            $data["first_name"] = $params["fname"];
+        }
+        if (isset($params["lname"])) {
+            $data["last_name"] = $params["lname"];
+        }
+        if (isset($params["phone2"])) {
+            $data["phone"] = $params["phone2"];
+        }
+        if (isset($params["phone1"])) {
+            $data["mobile"] = $params["phone1"];
+        }
+        if (isset($params["semail"])) {
+            $data["secondary_email"] = $params["semail"];
+        }
 	    if (isset($params['institute']) && $params['institute'] != "") {
             $data['institute'] = $params['institute'];
         }

--- a/application/models/DbTable/Participants.php
+++ b/application/models/DbTable/Participants.php
@@ -751,12 +751,21 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract {
         echo json_encode($output);
     }
 
-    public function addParticipantManager($params){
-         $db = Zend_Db_Table_Abstract::getAdapter();
-         if (isset($params['datamanagerId']) && $params['datamanagerId'] != "") {
+    public function addParticipantManager($params)
+    {
+        $db = Zend_Db_Table_Abstract::getAdapter();
+        if (isset($params['datamanagerId']) && $params['datamanagerId'] != ""
+            && isset($params['participantId'])
+            && $params['participantId'] != null
+            && $params['participantId'] != "") {
+            $db->delete('participant_manager_map',"dm_id = " . $params['datamanagerId'] . " AND participant_id = " . $params['participantId']);
+            foreach ($params['participants'] as $participantId) {
+                $db->insert('participant_manager_map',array('participant_id'=>$participantId,'dm_id'=>$params['datamanagerId']));
+            }
+        } else if (isset($params['datamanagerId']) && $params['datamanagerId'] != "") {
              $db->delete('participant_manager_map',"dm_id = " . $params['datamanagerId']);
-             foreach ($params['participants'] as $participants) {
-                 $db->insert('participant_manager_map',array('participant_id'=>$participants,'dm_id'=>$params['datamanagerId']));
+             foreach ($params['participants'] as $participantId) {
+                 $db->insert('participant_manager_map',array('participant_id'=>$participantId,'dm_id'=>$params['datamanagerId']));
              }
          } else if (isset($params['participantId']) && $params['participantId'] != "") {
              $db->delete('participant_manager_map',"participant_id = " . $params['participantId']);

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -757,8 +757,8 @@ class Application_Service_Participants {
             $username = "none";
             if (isset($tempParticipants[$i]["Username"]) && $tempParticipants[$i]["Username"]) {
                 $username = trim($tempParticipants[$i]["Username"]);
-                if (!preg_match("~^[\dA-Za-z@\.-]*$~", $username)) {
-                    throw new Exception("The sheet contains an invalid username ".$username." for PT ID ".$tempParticipants[$i]["PT ID"].". Usernames may only contain numbers, letters, @ signs, hyphens and periods. No spaces, semi colons or other special characters are allowed.");
+                if (!preg_match("~^[\dA-Za-z@\.\-_]*$~", $username)) {
+                    throw new Exception("The sheet contains an invalid username ".$username." for PT ID ".$tempParticipants[$i]["PT ID"].". Usernames may only contain numbers, letters, @ signs, hyphens, underscores and periods. No spaces, semi colons or other special characters are allowed.");
                 }
             }
             if (isset($tempParticipantsMap[$tempParticipants[$i]["PT ID"]][$username])) {
@@ -803,7 +803,7 @@ class Application_Service_Participants {
             } else {
                 throw new Exception("The sheet contains a record where the country cannot be determined. Please check ".$tempParticipants[$i]["PT ID"]." in ".$tempParticipants[$i]["Country"]." to make sure that the country name is correctly spelled?");
             }
-            if (isset($existingDataManagersMap[$tempParticipants[$i]["Username"]])) {
+            if (isset($existingDataManagersMap[$tempParticipants[$i]["Username"]]) && isset($existingDataManagersMap[$username])) {
                 $tempParticipantsMap[$tempParticipants[$i]["PT ID"]][$username]["dm_id"] = $existingDataManagersMap[$username]["dm_id"];
             }
             if (isset($existingParticipantsMap[$tempParticipants[$i]["PT ID"]])) {

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -889,12 +889,17 @@ class Application_Service_Participants {
                     $tempParticipantsMap[$ptId][$participantUsername]["Username"] &&
                     (strlen($participantUsername) < 12 || substr($participantUsername, -12, 10) != "systemone.") &&
                     (strlen($participantEmailAddress) < 12 || substr($participantEmailAddress, -12, 10) != "systemone.")) {
-                    $tempParticipantsMap[$ptId][$participantUsername]["Username"] = $participantEmailAddress;
+                    $tempParticipantsMap[$ptId][$participantUsername]["Username"] = trim($participantEmailAddress);
                 }
                 if ($tempParticipantsMap[$ptId][$participantUsername]["Username"]) {
                     $tempParticipantsMap[$ptId][$participantUsername]["status"] = $tempParticipantsMap[$ptId][$participantUsername]["Active"] == "No" ? "inactive" : "active";
                 }
                 $tempParticipantsMap[$ptId][$participantUsername]["participant_status"] = $participantActive == "No" ? "inactive" : "active";
+                if (!isset($tempParticipantsMap[$ptId][$participantUsername]["password"])
+                    || $tempParticipantsMap[$ptId][$participantUsername]["password"] == null
+                    || trim($tempParticipantsMap[$ptId][$participantUsername]["password"]) == "") {
+                    $record["password"] = "XTPT2022!";
+                }
                 $tempParticipantInserts[] = $tempParticipantsMap[$ptId][$participantUsername];
             }
         }

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -1147,7 +1147,6 @@ class Application_Service_Participants {
                     $participantDb->updateParticipant($updatedParticipant);
                 }
             } else if ($participantTempRecord["insert_user_link"]) {
-                $participant = $participantDb->getParticipant($participantTempRecord["participant_id"]);
                 $dataManagerToLink = null;
                 if ($participantTempRecord["dm_id"] != null) {
                     $dataManagerToLink = $userService->getUserInfoBySystemId($participantTempRecord["dm_id"]);
@@ -1156,8 +1155,22 @@ class Application_Service_Participants {
                 }
                 $participantDb->addParticipantManager(array(
                     "datamanagerId" => $dataManagerToLink["dm_id"],
-                    "participants" => array($participant["participant_id"])
+                    "participantId" => $participantTempRecord["participant_id"],
+                    "participants" => array($participantTempRecord["participant_id"])
                 ));
+                if ((isset($participantTempRecord["username"]) && $participantTempRecord["username"]) ||
+                    (isset($participantTempRecord["password"]) && $participantTempRecord["password"])) {
+                    $updatedUser = array(
+                        "userSystemId" => $dataManagerToLink["dm_id"]
+                    );
+                    if (isset($participantTempRecord["username"]) && $participantTempRecord["username"]) {
+                        $updatedUser["userId"] = $participantTempRecord["username"];
+                    }
+                    if (isset($participantTempRecord["username"]) && $participantTempRecord["username"]) {
+                        $updatedUser["password"] = $participantTempRecord['password'];
+                    }
+                    $userService->updateUser($updatedUser);
+                }
             }
         }
 

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -901,7 +901,7 @@ class Application_Service_Participants {
                 if (!isset($tempParticipantsMap[$ptId][$participantUsername]["password"])
                     || $tempParticipantsMap[$ptId][$participantUsername]["password"] == null
                     || trim($tempParticipantsMap[$ptId][$participantUsername]["password"]) == "") {
-                    $record["password"] = "XTPT2022!";
+                    $tempParticipantsMap[$ptId][$participantUsername]["password"] = "XTPT2022!";
                 }
                 $tempParticipantInserts[] = $tempParticipantsMap[$ptId][$participantUsername];
             }
@@ -1064,8 +1064,8 @@ class Application_Service_Participants {
                         "fundingSource" => $participant["funding_source"]
                     );
                     $dataManagerToUpdate = null;
-                    if ($dataManagerToUpdate["dm_id"] != null) {
-                        $dataManagerToUpdate = $userService->getUserInfoBySystemId($dataManagerToUpdate["dm_id"]);
+                    if ($participantTempRecord["dm_id"] != null) {
+                        $dataManagerToUpdate = $userService->getUserInfoBySystemId($participantTempRecord["dm_id"]);
                     } else {
                         $dataManagerToUpdate = $userService->getUserInfo($participantTempRecord["username"]);
                     }
@@ -1149,8 +1149,8 @@ class Application_Service_Participants {
             } else if ($participantTempRecord["insert_user_link"]) {
                 $participant = $participantDb->getParticipant($participantTempRecord["participant_id"]);
                 $dataManagerToLink = null;
-                if ($dataManagerToUpdate["dm_id"] != null) {
-                    $dataManagerToLink = $userService->getUserInfoBySystemId($dataManagerToUpdate["dm_id"]);
+                if ($participantTempRecord["dm_id"] != null) {
+                    $dataManagerToLink = $userService->getUserInfoBySystemId($participantTempRecord["dm_id"]);
                 } else {
                     $dataManagerToLink = $userService->getUserInfo($participantTempRecord["username"]);
                 }

--- a/application/services/Participants.php
+++ b/application/services/Participants.php
@@ -756,7 +756,10 @@ class Application_Service_Participants {
             }
             $username = "none";
             if (isset($tempParticipants[$i]["Username"]) && $tempParticipants[$i]["Username"]) {
-                $username = $tempParticipants[$i]["Username"];
+                $username = trim($tempParticipants[$i]["Username"]);
+                if (!preg_match("~^[\dA-Za-z@\.-]*$~", $username)) {
+                    throw new Exception("The sheet contains an invalid username ".$username." for PT ID ".$tempParticipants[$i]["PT ID"].". Usernames may only contain numbers, letters, @ signs, hyphens and periods. No spaces, semi colons or other special characters are allowed.");
+                }
             }
             if (isset($tempParticipantsMap[$tempParticipants[$i]["PT ID"]][$username])) {
                 throw new Exception("The sheet contains a duplicate records for ".$tempParticipants[$i]["PT ID"]." and ".$username.".");

--- a/application/services/Reports.php
+++ b/application/services/Reports.php
@@ -3934,9 +3934,9 @@ class Application_Service_Reports {
             // Strip out non-PTCC fields
             $pattern = '/--\s[-]+ START NON-PTCC COORDINATOR FIELDS [-]+(?s).*--\s[-]+ END NON-PTCC COORDINATOR FIELDS [-]+/';
             $queryString = preg_replace($pattern, '', $queryString);
-            $query = $db->query($queryString, [$shipmentId, sprintf('%s', implode(', ', $authNameSpace->countries))]);
+            $query = $db->query($queryString, [$shipmentId, implode(',', $authNameSpace->countries)]);
         } else {
-            // Strip out non-PTCC fields
+            // Strip out non-PTCC filters
             $pattern = '/--\s[-]+ START PTCC COORDINATOR FILTER [-]+(?s).*--\s[-]+ END PTCC COORDINATOR FILTER [-]+/';
             $queryString = preg_replace($pattern, '', $queryString);
             $query = $db->query($queryString, [$shipmentId]);

--- a/application/services/Reports/getTbAllSitesResultsSheet.sql
+++ b/application/services/Reports/getTbAllSitesResultsSheet.sql
@@ -850,7 +850,7 @@ FROM
             shipment.shipment_id = ?
 -- ----------------------------------------- START PTCC COORDINATOR FILTER --------------------------------------------
         AND
-            countries.id IN (?)
+            FIND_IN_SET(countries.id, ?)
 -- ------------------------------------------ END PTCC COORDINATOR FILTER ---------------------------------------------
         GROUP BY
             shipment_participant_map.map_id


### PR DESCRIPTION
- Adds validation for participant imports that contain badly formatted usernames
- Default's user password to XTPT2022!
- Default usernames to <PT ID>@ept.systemone.id

### To Test:
Some test import files have been added here: https://drive.google.com/drive/folders/1d-5hxStxNrNcJIG2Z2OSFGmc9VapiMcG?usp=sharing

#### Username Validation
Try to import one of the invalid participant worksheets:
- 0-Participant_Import_Template.xlsx
- 1-Participants-2022-A.xlsx
- 2-Participants-2022-A-Usernames-Cleaned.xlsx

Expected results, the system will validate the usernames and prevent the user from being able to confirm the import

#### Valid Import File
Try to import 3-Participants-2022-A-Usernames-Cleaned.xlsx and confirm the import.

- The system will assign a username to participants who don't have one
- The system will set the password to new users and existing users with no password to XTPT2022!